### PR TITLE
[FIX] elastic_service: Add support for 'in' operator into scoped queries and allows raw_es_query

### DIFF
--- a/lib/shop_invader/services/elastic_service.rb
+++ b/lib/shop_invader/services/elastic_service.rb
@@ -133,6 +133,9 @@ module ShopInvader
 
     def build_params(conditions)
       { bool: { filter: [], must_not: [] }}.tap do |params|
+        if conditions.key?('raw_es_query')
+            return conditions['raw_es_query']
+        end
         conditions.each do |key, value|
           name, op = key.split('.')
           build_attr(name, value).each do | name, value |

--- a/lib/shop_invader/services/elastic_service.rb
+++ b/lib/shop_invader/services/elastic_service.rb
@@ -142,6 +142,8 @@ module ShopInvader
               end
             elsif %w(gt gte lt lte).include?(op)
               params[:bool][:filter] << { range: { name => { op => value } } }
+            elsif op == "in"
+              params[:bool][:filter] << { terms: { name => value } }
             else
               params[:bool][:filter] << { term: { name => value } }
             end

--- a/spec/services/elastic_service_spec.rb
+++ b/spec/services/elastic_service_spec.rb
@@ -83,5 +83,13 @@ RSpec.describe ShopInvader::ElasticService do
       end
     end
 
+    context "with raw query" do
+     let(:conditions) { { 'raw_es_query' => {:bool => {:filter=>[{:terms=>{"attributes.color"=>["red", "yellow"]}}]} } } }
+
+      it 'returns 2 range filter"' do
+        expect(subject).to eq(:bool => {:filter=>[{:terms=>{"attributes.color"=>["red", "yellow"]}}]} )
+      end
+    end
+
   end
 end

--- a/spec/services/elastic_service_spec.rb
+++ b/spec/services/elastic_service_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe ShopInvader::ElasticService do
       end
     end
 
+    context "with nested in" do
+      let(:conditions) { { 'attributes.in' => {'color': ['red', 'yellow'] } } }
+
+      it 'returns 1 terms filter"' do
+        expect(subject).to eq(:bool => {:filter=>[{:terms=>{"attributes.color"=>["red", "yellow"]}}], :must_not=>[]})
+      end
+    end
 
     context "with nested facet filter" do
       let(:conditions) { { 'attributes' => {'color': 'red'} } }


### PR DESCRIPTION
```
{%with_scope raw_es_query: {filter:{terms:{attributes.color:['red', 'yellow']}}} %}
```

