### PR TITLE
[IMP] better detection of search engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify your gem's dependencies in shop_invader.gemspec
 gemspec
 
-gem 'locomotivecms_steam', github: 'akretion/steam', branch: 'fix-impersonnate'
-#gem 'locomotivecms_steam', path: '/gems/steam'
+gem 'locomotivecms_steam', github: 'locomotivecms/steam'
 gem 'faraday'
 gem 'algoliasearch'
 gem 'elasticsearch'

--- a/lib/shop_invader/services/algolia_service.rb
+++ b/lib/shop_invader/services/algolia_service.rb
@@ -32,7 +32,7 @@ module ShopInvader
     end
 
     def is_configured?
-     !!@site.metafields['algolia']
+      !!(@site.metafields_schema.find { |s| s['name'] == 'algolia' } && @site.metafields.dig('algolia', 'application_id'))
     end
 
     def find_all_products_and_categories

--- a/lib/shop_invader/services/elastic_service.rb
+++ b/lib/shop_invader/services/elastic_service.rb
@@ -24,7 +24,7 @@ module ShopInvader
     end
 
     def is_configured?
-     !!@site.metafields['elasticsearch']
+      !!(@site.metafields_schema.find { |s| s['name'] == 'elasticsearch' } && @site.metafields.dig('elasticsearch', 'url'))
     end
 
     def find_all_products_and_categories

--- a/spec/services/algolia_service_spec.rb
+++ b/spec/services/algolia_service_spec.rb
@@ -13,10 +13,37 @@ RSpec.describe ShopInvader::AlgoliaService do
     },
     'erp' => { 'default_role' => 'public_tax_inc' }
   } }
-  let(:site)      { instance_double('Site', metafields: metafields, locales: ['en']) }
+  let(:metafields_schema) { [{'name' => 'algolia'}] }
+  let(:site)      { instance_double('Site', metafields: metafields, metafields_schema: metafields_schema, locales: ['en']) }
   let(:customer)  { nil }
   let(:locale)    { 'fr' }
   let(:service)   { described_class.new(site, customer, locale) }
+
+  describe 'Test if it is configured' do
+
+    subject { service.send(:is_configured?) }
+
+    context "Algolia is configured" do
+      it 'returns True (configured)' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "Algolia is configured but metafield is missing" do
+      let(:metafields_schema) { [] }
+
+      it 'returns False (not configured)' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context "Algolia is not configured but metafield exist" do
+      let(:metafields)  { {} }
+      it 'returns False (not configured)' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
 
   describe '#build_index_name for local fr' do
 

--- a/spec/services/elastic_service_spec.rb
+++ b/spec/services/elastic_service_spec.rb
@@ -2,11 +2,38 @@ require 'spec_helper'
 
 RSpec.describe ShopInvader::ElasticService do
 
-  let(:metafields)  { { 'elasticsearch' => { } } }
-  let(:site)      { instance_double('Site', metafields: metafields, locales: ['en']) }
+  let(:metafields)  { { 'elasticsearch' => { 'url' => 'http://elastic' }} }
+  let(:metafields_schema) { [{'name' => 'elasticsearch'}] }
+  let(:site)      { instance_double('Site', metafields: metafields, metafields_schema: metafields_schema, locales: ['en']) }
   let(:customer)  { nil }
   let(:locale)    { 'fr' }
   let(:service)   { described_class.new(site, customer, locale) }
+
+  describe 'Test if it is configured' do
+
+    subject { service.send(:is_configured?) }
+
+    context "Elasticsearch is configured" do
+      it 'returns True (configured)' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "Elasticsearch is configured but metafield is missing" do
+      let(:metafields_schema) { [] }
+
+      it 'returns False (not configured)' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context "Elasticsearch is not configured but metafield exist" do
+      let(:metafields)  { {} }
+      it 'returns False (not configured)' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
 
   describe '#build_index_name for local fr' do
 

--- a/spec/services/search_engine_service_spec.rb
+++ b/spec/services/search_engine_service_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe ShopInvader::SearchEngineService do
   let(:indices)     { '[{ "name": "products", "index": "ci_shopinvader_variant" }, { "name": "categories", "index": "ci_shopinvader_category" }]' }
   let(:routes)      { '[]' }
   let(:metafields)  { {} }
-  let(:site)      { instance_double('Site', metafields: metafields, locales: ['en']) }
+  let(:metafields_schema)  { {} }
+  let(:site)      { instance_double('Site', metafields: metafields, metafields_schema: metafields_schema, locales: ['en']) }
   let(:customer)  { nil }
   let(:locale)    { 'en' }
   let(:elastic)   { ShopInvader::ElasticService.new(site, customer, locale) }
@@ -25,6 +26,7 @@ RSpec.describe ShopInvader::SearchEngineService do
             'routes'          => routes
             }
           } }
+        let(:metafields_schema) { [{'name' => 'elasticsearch'}] }
 
       elsif backend == 'algolia'
 
@@ -37,6 +39,7 @@ RSpec.describe ShopInvader::SearchEngineService do
             'routes'          => routes
             }
           } }
+        let(:metafields_schema) { [{'name' => 'algolia'}] }
 
       end
 

--- a/spec/services_spec.rb
+++ b/spec/services_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 RSpec.describe Locomotive::Steam::Services do
 
   let(:request) { instance_double('Request', env: {}) }
-  let(:site) { instance_double('Site', metafields: { 'algolia' => { 'application_id' => '42', 'api_key' => '42' } }) }
+  let(:site) { instance_double('Site',
+      metafields: { 'algolia' => { 'application_id' => '42', 'api_key' => '42' } },
+      metafields_schema: [{ 'name' => 'algolia'}]
+  ) }
 
   before do
     allow_any_instance_of(Locomotive::Steam::SiteFinderService).to receive(:find).and_return(site)

--- a/spec/support/steam.rb
+++ b/spec/support/steam.rb
@@ -1,12 +1,14 @@
 def build_services_for_algolia(application_id: '42', api_key: '42', indices: [])
   request = instance_double('Request', env: {})
-  site    = instance_double('Site', metafields: {
-    'algolia' => {
-      'application_id'  => application_id,
-      'api_key'         => api_key,
-      'indices'         => indices
-    }
-  })
+  site    = instance_double('Site',
+    metafields: {
+      'algolia' => {
+        'application_id'  => application_id,
+        'api_key'         => api_key,
+        'indices'         => indices
+      }},
+    metafields_schema: [{'name' => 'algolia'}]
+  )
 
   allow_any_instance_of(Locomotive::Steam::SiteFinderService).to receive(:find).and_return(site)
 
@@ -15,13 +17,15 @@ end
 
 def build_services_for_elasticsearch(server_IP: '1.1.1.1', server_Port: '9200', indices: [])
   request = instance_double('Request', env: {})
-  site    = instance_double('Site', metafields: {
-    'elasticsearch' => {
-      'server_IP'  => server_IP,
-      'server_Port'  => server_Port,
-      'indices'  => indices
-    }
-  })
+  site    = instance_double('Site',
+    metafields: {
+      'elasticsearch' => {
+        'server_IP'  => server_IP,
+        'server_Port'  => server_Port,
+        'indices'  => indices
+      }},
+    metafields_schema: [{'name' => 'elasticsearch'}]
+  )
 
   allow_any_instance_of(Locomotive::Steam::SiteFinderService).to receive(:find).and_return(site)
 


### PR DESCRIPTION
For using a search engine we check that
- the schema have the key
- the data is configured (check application id for algolia and url for
elasctic)

Now if you remove one of the search engine in the metafield, the search
engine is not used anymore.
If you remove the application_id of algolia configuration or the url
for elastic, this search engine are not used anymore