### PR TITLE
[4.0][FIX] selected lang is no more properly forwarded to Odoo

### DIFF
--- a/lib/shop_invader/services/erp_service.rb
+++ b/lib/shop_invader/services/erp_service.rb
@@ -182,7 +182,7 @@ module ShopInvader
     def get_header_for_request(locale, request)
       headers = {
         api_key: @site.metafields['erp']['api_key'],
-        acept_language: map_locale(locale.to_s),
+        accept_language: map_locale(locale.to_s),
       }
       add_client_header(request, headers)
       add_header_info_from_session(headers)


### PR DESCRIPTION
fix typo into header introduced in fe895e2bc85e7a4e5164b70ef4a9c66762c079d7

ping @sebastienbeau 