### PR TITLE
[FIX] Fix issue that restrict to 10 variants

### DIFF
--- a/lib/shop_invader/services/elastic_service.rb
+++ b/lib/shop_invader/services/elastic_service.rb
@@ -121,7 +121,15 @@ module ShopInvader
       }
       response = @client.search(
         index: find_index_name(name),
-        body: body
+        body: body,
+        # by default the size is 10
+        # which restrict to 10 variant
+        # we put a really high limit of variant
+        # because we do not want to have a limit
+        # if we have more then 10000 variants
+        # we certainly will have some perf issue before
+        # so we will latter see how to manage this case
+        size: 10000,
       )
       response = _parse_response(response)
       resource = nil


### PR DESCRIPTION
Elastic client limit by 10 the number of record return
In case of searching a product we when all variants without limit
This quick fix set to 10000 the limit.
If we have more then 10000 variants we will have an issue.
But having 10000 variants should never occured and maybe we should
manage them in a different way.
So let's see how to fix this issue the day we will have it.
One possible thing is to add a optionnal config and keeping this
default value.