### PR TITLE
[IMP] Drop recaptcha response from request once it is validated

### DIFF
--- a/lib/shop_invader/middlewares/erp_proxy.rb
+++ b/lib/shop_invader/middlewares/erp_proxy.rb
@@ -8,7 +8,7 @@ module ShopInvader
       def _call
         if env['steam.path'].start_with?('invader/')
           path = env['steam.path'].sub('invader/', '')
-          if recaptcha_required(path) && !is_recaptcha_verified?(params["g-recaptcha-response"])
+          if recaptcha_required(path) && !is_recaptcha_verified?(params.delete("g-recaptcha-response"))
             if force_redirection || html_form_edition
               return _process_error_redirection
             else


### PR DESCRIPTION
Using recaptcha on content type is fine, but when trying to use it directly to an Odoo Rest API request, recaptcha response needs to be added to rest framework validators.
As validation takes place on locomotive itself, once google recaptcha is validated we can pop it from the request.

WDYT @sebastienbeau @lmignon @did