### PR TITLE
[fix] erp_service.parse_response: fix content-type parsing

### DIFF
--- a/lib/shop_invader/services/erp_service.rb
+++ b/lib/shop_invader/services/erp_service.rb
@@ -89,7 +89,7 @@ module ShopInvader
 
     def parse_response(response)
       headers = response.headers
-      if headers['content-type'] == 'application/json'
+      if headers['content-type']&.include?('application/json')
         res = JSON.parse(response.body)
         if res.include?('set_session')
             res.delete('set_session').each do |key, val|


### PR DESCRIPTION
Content-Type header might contain some other info, like application/json; charset=utf-8. This fixes compatibility with Odoo v18.