### PR TITLE
[fix] erp_service.parse_response: fix content-type parsing

### DIFF
--- a/lib/shop_invader/middlewares/erp_proxy.rb
+++ b/lib/shop_invader/middlewares/erp_proxy.rb
@@ -16,7 +16,7 @@ module ShopInvader
             end
           end
           response = erp.call_without_parsing(env['REQUEST_METHOD'], path, params)
-          if response.status == 200 && response.headers["content-type"] != "application/json"
+          if response.status == 200 && !response.headers["content-type"]&.include?('application/json')
             _render_download(response)
           elsif force_redirection || html_form_edition
             _process_redirection(response)

--- a/lib/shop_invader/services/erp_service.rb
+++ b/lib/shop_invader/services/erp_service.rb
@@ -89,7 +89,7 @@ module ShopInvader
 
     def parse_response(response)
       headers = response.headers
-      if headers['content-type'] == 'application/json'
+      if headers['content-type']&.include?('application/json')
         res = JSON.parse(response.body)
         if res.include?('set_session')
             res.delete('set_session').each do |key, val|


### PR DESCRIPTION
Content-Type header might contain some other info, like application/json; charset=utf-8. This fixes compatibility with Odoo v18.

Replaces https://github.com/shopinvader/locomotive-shopinvader/pull/89